### PR TITLE
Add admin option to disable all upload emails site-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: lenasterg, NTS on cti.gr, sch.gr
 Tags:  buddypress, group documents, file, storage, widget
 Requires at least: 4.6
 Tested up to: 6.7.2
-Stable tag: 2.1
+Stable tag: 2.1.1
 License:           GNU General Public License v2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 										  
@@ -96,6 +96,9 @@ Add to your Customizer 'Custom CSS' panel the following:
 
 
 ## Changelog
+
+= Version 2.1.1 (18 June 2026) =
+* New: Admin setting "Disable All Emails" to override per-user preferences and turn off document-upload emails site-wide.
 
 = Version 2.1 (10 July 2025) =
 * Bug fix: A user can edit and delete his/her uploaded files

--- a/include/admin.php
+++ b/include/admin.php
@@ -59,6 +59,14 @@ function bp_group_documents_admin()
         update_option('bp_group_documents_display_date', $bg_date);
 
         //turn absense of true into an explicit false
+        if (isset($_POST['disable_email_notifications']) && $_POST['disable_email_notifications'] ) {
+            $disable_email_notifications = 1;
+        } else {
+            $disable_email_notifications = 0;
+        }
+        update_option('bp_group_documents_disable_email_notifications', $disable_email_notifications);
+
+        //turn absense of true into an explicit false
         if (isset($_POST['use_categories']) && $_POST['use_categories'] ) {
             $categories = 1;
         } else {
@@ -100,6 +108,7 @@ function bp_group_documents_admin()
     $display_icons          = get_option('bp_group_documents_display_icons');
     $display_owner          = get_option('bp_group_documents_display_owner');
     $display_date          = get_option('bp_group_documents_display_date');
+    $disable_email_notifications = get_option('bp_group_documents_disable_email_notifications');
     $use_categories         = get_option('bp_group_documents_use_categories');
     $items_per_page         = get_option('bp_group_documents_items_per_page');
     $upload_permission      = get_option('bp_group_documents_upload_permission');
@@ -224,6 +233,19 @@ function bp_group_documents_admin()
                         }
                         ?>
          value="1" /></td>
+                </tr>
+                <tr>
+                    <th><label for="disable_email_notifications"><?php esc_html_e('Disable All Emails', 'bp-group-documents'); ?>:</label></th>
+                    <td>
+                        <input type="checkbox" name="disable_email_notifications" id="disable_email_notifications"
+                        <?php
+                        if ($disable_email_notifications ) {
+                            echo 'checked="checked"';
+                        }
+                        ?>
+         value="1" />
+                        <p class="description"><?php esc_html_e('Override Users settings and completely disable email notification when a document is uploaded.', 'bp-group-documents'); ?></p>
+                    </td>
                 </tr>
             </table>
             <p class="submit">

--- a/include/notifications.php
+++ b/include/notifications.php
@@ -160,4 +160,9 @@ To download the new document directly: %8$s
     } //end foreach
 }
 
-add_action('bp_group_documents_add_success', 'bp_group_documents_email_notification', 10);
+// Site administrators can override every member's per-user preference and disable
+// upload email notifications site-wide via the plugin settings screen. When that
+// option is set, the email notification action is never registered.
+if (! get_option('bp_group_documents_disable_email_notifications') ) {
+    add_action('bp_group_documents_add_success', 'bp_group_documents_email_notification', 10);
+}

--- a/loader.php
+++ b/loader.php
@@ -3,8 +3,8 @@
  * Plugin Name: BP Group Documents
  * Plugin URI: https://wordpress.org/plugins/bp-group-documents/
  * Description: BP Group Documents creates a page within each BuddyPress group to upload and any type of file or document.
- * Version: 2.1
- * Revision Date: July 10, 2025
+ * Version: 2.1.1
+ * Revision Date: June 18, 2026
  * Requires at least: 4.6
  * Tested up to: 6.7.2, BuddyPress 14.4.1
  * License: GNU General Public License v2 or later
@@ -25,7 +25,7 @@ defined('ABSPATH') || exit;
 
 //some constants that can be checked when extending this plugin
 define('BP_GROUP_DOCUMENTS_IS_INSTALLED', 1);
-define('BP_GROUP_DOCUMENTS_VERSION', '2.1');
+define('BP_GROUP_DOCUMENTS_VERSION', '2.1.1');
 define('BP_GROUP_DOCUMENTS_DB_VERSION', '6');
 define('BP_GROUP_DOCUMENTS_VALID_FILE_FORMATS', 'doc, docx, gif, gz, jpeg, jpg, ods, odt, pdf, png, pps, ppsx, ppt, pptx, rtf, tar, txt, xls, xlsx, zip');
 define('BP_GROUP_DOCUMENTS_ITEMS_PER_PAGE', 20);
@@ -37,6 +37,8 @@ define('BP_GROUP_DOCUMENTS_USE_CATEGORIES', 1);
 define('BP_GROUP_DOCUMENTS_ENABLE_ALL_GROUPS', true);
 define('BP_GROUP_DOCUMENTS_PROGRESS_BAR', 1);
 define('BP_GROUP_DOCUMENTS_FORUM_ATTACHMENTS', 0);
+//when set, the site administrator can override per-user settings and disable upload email notifications site-wide
+define('BP_GROUP_DOCUMENTS_DISABLE_EMAIL_NOTIFICATIONS', 0);
 
 
 //allow override of URL slug
@@ -146,6 +148,7 @@ function bp_group_documents_install_upgrade()
         add_option('bp_group_documents_enable_all_groups', BP_GROUP_DOCUMENTS_ENABLE_ALL_GROUPS);
         add_option('bp_group_documents_progress_bar', BP_GROUP_DOCUMENTS_PROGRESS_BAR);
         add_option('bp_group_documents_forum_attachments', BP_GROUP_DOCUMENTS_FORUM_ATTACHMENTS);
+        add_option('bp_group_documents_disable_email_notifications', BP_GROUP_DOCUMENTS_DISABLE_EMAIL_NOTIFICATIONS);
         add_option('bp-group-documents-db-version', BP_GROUP_DOCUMENTS_DB_VERSION);
     }
     if (( get_site_option('bp-group-documents-db-version') ) && ( get_site_option('bp-group-documents-db-version') < 6 ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: lenasterg, NTS on cti.gr, sch.gr
 Tags:  buddypress, group documents, file, storage, widget
 Requires at least: 4.6
 Tested up to: 6.7.2
-Stable tag: 2.1
+Stable tag: 2.1.1
 License:           GNU General Public License v2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -95,6 +95,9 @@ Add to your Customizer 'Custom CSS' panel the following:
 
 
 == Changelog ==
+= Version 2.1.1 (18 June 2026) =
+* New: Admin setting "Disable upload email notifications" to override per-user preferences and turn off document-upload emails site-wide.
+
 = Version 2.1 (10 July 2025) =
 * Bug fix: A user can edit and delete his/her uploaded files
 


### PR DESCRIPTION
Description:
## What
Adds a "Disable All Emails" checkbox to the plugin settings screen. When ticked, it overrides every member's individual notification preference and stops document-upload emails for the entire site.

## Why
The upload notification loops over the full group membership, sending one email per member on every upload. For large groups this floods users with mail on every upload, and the only existing control is per-user (opt-out, defaulting to on) — there's no global switch for a site admin. This adds one.

## How
- `loader.php`: register `bp_group_documents_disable_email_notifications` option (default 0) and bump version to 2.1.1
- `include/notifications.php`: gate the upload-email hook on the new option
- `include/admin.php`: add the checkbox, save handler, and description
- `readme.txt` / `README.md`: changelog entry, stable tag 2.1.1

## Compatibility
Default unchecked — existing per-user behaviour is unchanged. Fully backward compatible; the override is purely opt-in.